### PR TITLE
Update hyperhtml meta

### DIFF
--- a/libraries/hyperhtml/meta/summary.md
+++ b/libraries/hyperhtml/meta/summary.md
@@ -1,17 +1,10 @@
 <h4 id="hyperhtml-handling-data">Handling data</h4>
 
-hyperHTML is compatible with <a href="https://viperhtml.js.org/hyperhtml/documentation/#essentials-4">different kind of attributes</a>,
-including boolean, custom elements special cases, events, and of course regular attributes.<br>
-The latter are always set in an observable way through <code>node.setAttribute(name, value)</code>,
-with the only exception of the <code>data</code> attribute.
-In such case, you can pass along any rich value including arrays or objects.
+hyperHTML will pass data to an element as properties, as long as the property
+is defined on the element's prototype. Otherwise it will fallback to passing
+data as attributes.
 
 <h4 id="hyperhtml-handling-events">Handling events</h4>
 
-hyperHTML is compatible with DOM Level 3 events.
-This includes the ability to use both functions and even
-objects implementing the <a href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">EventListener interface</a>.<br>
-
-With HyperHTMLElement there are <a href="https://github.com/WebReflection/hyperHTML-Element#the-class">3 extra patterns</a> to set events: based on automatically available <code>handleEvent</code> interface,
-a declarative <code>data-call</code>, and a Preact<i>ish</i> style
-with lazily bound <code>handleClick</code> methods and friends.
+hyperHTML can listen to native DOM events dispatched from Custom Elements. It
+supports all styles of events (lowercase, camelCase, kebab-case, etc).


### PR DESCRIPTION
@WebReflection I updated the hyperHTML meta so it's more similar to the one from other libraries like CanJS. I did this because the original version was difficult for me to understand. I realize it's a significant rewrite :) but I'm trying to just convey the important facts without worrying so much about which library feature the user leverages to get there.