### PR TITLE
Latest hyperHTML with proper Custom Elements initialization

### DIFF
--- a/libraries/hyperhtml/package.json
+++ b/libraries/hyperhtml/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@webcomponents/webcomponentsjs": "^1.0.1",
-    "hyperhtml": "1.10.2",
+    "hyperhtml": "1.11.1",
     "hyperhtml-element": "0.6.0"
   }
 }

--- a/libraries/hyperhtml/src/component-tests.js
+++ b/libraries/hyperhtml/src/component-tests.js
@@ -101,34 +101,34 @@ describe('with children', function() {
 
 describe('attributes and properties', function() {
   it('will pass boolean data as either an attribute or a property', function() {
-    root.appendChild(ComponentWithProperties());
+    ComponentWithProperties(root);
     let wc = root.querySelector('#wc');
     let data = wc.bool || wc.hasAttribute('bool');
     expect(data).toBe(true);
   });
 
   it('will pass numeric data as either an attribute or a property', function() {
-    root.appendChild(ComponentWithProperties());
+    ComponentWithProperties(root);
     let wc = root.querySelector('#wc');
     let data = wc.num || wc.getAttribute('num');
     expect(data).toEqual(42);
   });
 
   it('will pass string data as either an attribute or a property', function() {
-    root.appendChild(ComponentWithProperties());
+    ComponentWithProperties(root);
     let wc = root.querySelector('#wc');
     let data = wc.str || wc.getAttribute('str');
     expect(data).toEqual('hyperHTML');
   });
 
   it('will pass array data as a property', function() {
-    root.appendChild(ComponentWithProperties());
+    ComponentWithProperties(root);
     let wc = root.querySelector('#wc');
     expect(wc.arr).toEqual(['h', 'y', 'p', 'e', 'r', 'H', 'T', 'M', 'L']);
   });
 
   it('will pass object data as a property', function() {
-    root.appendChild(ComponentWithProperties());
+    ComponentWithProperties(root);
     let wc = root.querySelector('#wc');
     expect(wc.obj).toEqual({org: 'viperHTML', repo: 'hyperHTML'});
   });

--- a/libraries/hyperhtml/src/components.js
+++ b/libraries/hyperhtml/src/components.js
@@ -67,7 +67,7 @@ export class ComponentWithDifferentViews extends HyperHTMLELement {
 }
 ComponentWithDifferentViews.define('with-children-diff-views');
 
-export const ComponentWithProperties = () => hyper`
+export const ComponentWithProperties = (root) => hyper(root)`
   <div>
     <ce-with-properties id="wc"
       bool=${true}


### PR DESCRIPTION
Due to issue [#671](https://github.com/w3c/webcomponents/issues/671)
it is not possible to synchronously set attributes passing
through the custom element prototype when an element
comes from a template and it's not already live.

Previous version of hyperHTML was somehow cheating and
attaching properties to the element directly,
shadowing its inherited behaviour after upgrade to CE.

The issue is explained in here:
https://github.com/w3c/webcomponents/issues/671#issuecomment-332867127

This PR uses live nodes instad of template one
so that the test passes without needing any special tratment.