### PR TITLE
Make libraries' build & test cross-platform

### DIFF
--- a/libraries/angular/package-lock.json
+++ b/libraries/angular/package-lock.json
@@ -1457,6 +1457,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cpr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-2.2.0.tgz",
+      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",

--- a/libraries/angular/package.json
+++ b/libraries/angular/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "test": "cross-env LIBRARY_NAME=@angular/core karma start",
-    "build": "npm run test; DIST=../../docs/libraries/angular && mkdir -p $DIST && cp -r ./meta $DIST/meta && cp -r ./results $DIST/results"
+    "test": "cross-env LIBRARY_NAME=\"@angular/core\" karma start",
+    "build": "npm run test && cross-env-shell DIST=../../docs/libraries/angular \"mkdirp $DIST && cpr ./meta $DIST/meta --overwrite && cpr ./results $DIST/results --overwrite\""
   },
   "devDependencies": {
     "@types/mocha": "2.2.43",
@@ -11,6 +11,7 @@
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
     "babel-preset-es2015": "6.24.1",
+    "cpr": "^2.2.0",
     "cross-env": "5.1.0",
     "expect": "1.20.2",
     "karma": "1.7.1",
@@ -20,6 +21,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-structured-json-reporter": "1.0.1",
     "karma-webpack": "2.0.5",
+    "mkdirp": "^0.5.1",
     "mocha": "4.0.1",
     "ts-helpers": "1.1.2",
     "typescript": "2.5.3",

--- a/libraries/angularjs/package-lock.json
+++ b/libraries/angularjs/package-lock.json
@@ -1147,6 +1147,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cpr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-2.2.0.tgz",
+      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",

--- a/libraries/angularjs/package.json
+++ b/libraries/angularjs/package.json
@@ -1,13 +1,14 @@
 {
   "scripts": {
     "test": "cross-env LIBRARY_NAME=angular karma start",
-    "build": "npm run test; DIST=../../docs/libraries/angularjs && mkdir -p $DIST && cp -r ./meta $DIST/meta && cp -r ./results $DIST/results"
+    "build": "npm run test && cross-env-shell DIST=../../docs/libraries/angularjs \"mkdirp $DIST && cpr ./meta $DIST/meta --overwrite && cpr ./results $DIST/results --overwrite\""
   },
   "devDependencies": {
     "angular-mocks": "1.6.6",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
     "babel-preset-es2015": "6.24.1",
+    "cpr": "^2.2.0",
     "cross-env": "5.1.0",
     "expect": "1.20.2",
     "karma": "1.7.1",
@@ -16,6 +17,7 @@
     "karma-mocha": "1.3.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.5",
+    "mkdirp": "^0.5.1",
     "mocha": "4.0.1",
     "webpack": "3.8.0"
   },

--- a/libraries/canjs/package-lock.json
+++ b/libraries/canjs/package-lock.json
@@ -1666,6 +1666,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cpr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-2.2.0.tgz",
+      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",

--- a/libraries/canjs/package.json
+++ b/libraries/canjs/package.json
@@ -1,13 +1,14 @@
 {
   "scripts": {
     "test": "cross-env LIBRARY_NAME=can-component karma start",
-    "build": "npm run test; DIST=../../docs/libraries/canjs && mkdir -p $DIST && cp -r ./meta $DIST/meta && cp -r ./results $DIST/results"
+    "build": "npm run test && cross-env-shell DIST=../../docs/libraries/canjs \"mkdirp $DIST && cpr ./meta $DIST/meta --overwrite && cpr ./results $DIST/results --overwrite\""
   },
   "devDependencies": {
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
     "babel-preset-es2015": "6.24.1",
     "copy-webpack-plugin": "4.1.1",
+    "cpr": "^2.2.0",
     "cross-env": "5.1.0",
     "expect": "1.20.2",
     "karma": "1.7.1",
@@ -16,6 +17,7 @@
     "karma-mocha": "1.3.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.5",
+    "mkdirp": "^0.5.1",
     "mocha": "4.0.1",
     "webpack": "3.8.0"
   },

--- a/libraries/dojo2/package-lock.json
+++ b/libraries/dojo2/package-lock.json
@@ -1199,6 +1199,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cpr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-2.2.0.tgz",
+      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",

--- a/libraries/dojo2/package.json
+++ b/libraries/dojo2/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "test": "cross-env LIBRARY_NAME=@dojo/core karma start",
-    "build": "npm run test; DIST=../../docs/libraries/dojo2 && mkdir -p $DIST && cp -r ./meta $DIST/meta && cp -r ./results $DIST/results"
+    "test": "cross-env LIBRARY_NAME=\"@dojo/core\" karma start",
+    "build": "npm run test && cross-env-shell DIST=../../docs/libraries/dojo2 \"mkdirp $DIST && cpr ./meta $DIST/meta --overwrite && cpr ./results $DIST/results --overwrite\""
   },
   "devDependencies": {
     "@types/expect": "1.20.2",
@@ -9,6 +9,7 @@
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
     "babel-preset-es2015": "6.24.1",
+    "cpr": "^2.2.0",
     "cross-env": "5.1.0",
     "expect": "1.20.2",
     "karma": "1.7.1",
@@ -17,6 +18,7 @@
     "karma-mocha": "1.3.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.5",
+    "mkdirp": "^0.5.1",
     "mocha": "4.0.1",
     "ts-loader": "3.0.2",
     "typescript": "2.5.3",

--- a/libraries/hyperhtml/package-lock.json
+++ b/libraries/hyperhtml/package-lock.json
@@ -1183,6 +1183,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cpr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-2.2.0.tgz",
+      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",

--- a/libraries/hyperhtml/package.json
+++ b/libraries/hyperhtml/package.json
@@ -1,13 +1,14 @@
 {
   "scripts": {
     "test": "cross-env LIBRARY_NAME=hyperhtml karma start",
-    "build": "npm run test; DIST=../../docs/libraries/hyperhtml && mkdir -p $DIST && cp -r ./meta $DIST/meta && cp -r ./results $DIST/results"
+    "build": "npm run test && cross-env-shell DIST=../../docs/libraries/hyperhtml \"mkdirp $DIST && cpr ./meta $DIST/meta --overwrite && cpr ./results $DIST/results --overwrite\""
   },
   "devDependencies": {
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
     "babel-preset-es2015": "6.24.1",
     "copy-webpack-plugin": "4.1.1",
+    "cpr": "^2.2.0",
     "cross-env": "5.1.0",
     "expect": "1.20.2",
     "karma": "1.7.1",
@@ -16,6 +17,7 @@
     "karma-mocha": "1.3.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.5",
+    "mkdirp": "^0.5.1",
     "mocha": "4.0.1",
     "webpack": "3.8.0"
   },

--- a/libraries/preact/package-lock.json
+++ b/libraries/preact/package-lock.json
@@ -1211,6 +1211,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cpr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-2.2.0.tgz",
+      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",

--- a/libraries/preact/package.json
+++ b/libraries/preact/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "test": "cross-env LIBRARY_NAME=preact karma start",
-    "build": "npm run test; DIST=../../docs/libraries/preact && mkdir -p $DIST && cp -r ./meta $DIST/meta && cp -r ./results $DIST/results"
+    "build": "npm run test && cross-env-shell DIST=../../docs/libraries/preact \"mkdirp $DIST && cpr ./meta $DIST/meta --overwrite && cpr ./results $DIST/results --overwrite\""
   },
   "devDependencies": {
     "babel-core": "6.26.0",
@@ -9,6 +9,7 @@
     "babel-plugin-transform-react-jsx": "6.24.1",
     "babel-preset-es2015": "6.24.1",
     "copy-webpack-plugin": "4.1.1",
+    "cpr": "^2.2.0",
     "cross-env": "5.1.0",
     "expect": "1.20.2",
     "karma": "1.7.1",
@@ -17,6 +18,7 @@
     "karma-mocha": "1.3.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.5",
+    "mkdirp": "^0.5.1",
     "mocha": "4.0.1",
     "webpack": "3.8.0"
   },

--- a/libraries/react/package-lock.json
+++ b/libraries/react/package-lock.json
@@ -1252,6 +1252,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cpr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-2.2.0.tgz",
+      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",

--- a/libraries/react/package.json
+++ b/libraries/react/package.json
@@ -1,13 +1,14 @@
 {
   "scripts": {
     "test": "cross-env LIBRARY_NAME=react karma start",
-    "build": "npm run test; DIST=../../docs/libraries/react && mkdir -p $DIST && cp -r ./meta $DIST/meta && cp -r ./results $DIST/results"
+    "build": "npm run test && cross-env-shell DIST=../../docs/libraries/react \"mkdirp $DIST && cpr ./meta $DIST/meta --overwrite && cpr ./results $DIST/results --overwrite\""
   },
   "devDependencies": {
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
+    "cpr": "^2.2.0",
     "cross-env": "5.1.0",
     "expect": "1.20.2",
     "karma": "1.7.1",
@@ -16,6 +17,7 @@
     "karma-mocha": "1.3.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.5",
+    "mkdirp": "^0.5.1",
     "mocha": "4.0.1",
     "webpack": "3.8.0"
   },

--- a/libraries/vue/package-lock.json
+++ b/libraries/vue/package-lock.json
@@ -1136,6 +1136,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cpr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-2.2.0.tgz",
+      "integrity": "sha512-q8UoWzIT9rslJKb3Y5CcByzR2zX7GBkVcoU6jJx02d/BgbE7zJ8Aix74i7bw3iYk58TrgXhmB2XB0aGaBd7oZA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",

--- a/libraries/vue/package.json
+++ b/libraries/vue/package.json
@@ -1,12 +1,13 @@
 {
   "scripts": {
     "test": "cross-env LIBRARY_NAME=vue karma start",
-    "build": "npm run test; DIST=../../docs/libraries/vue && mkdir -p $DIST && cp -r ./meta $DIST/meta && cp -r ./results $DIST/results"
+    "build": "npm run test && cross-env-shell DIST=../../docs/libraries/vue \"mkdirp $DIST && cpr ./meta $DIST/meta --overwrite && cpr ./results $DIST/results --overwrite\""
   },
   "devDependencies": {
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
     "babel-preset-es2015": "6.24.1",
+    "cpr": "^2.2.0",
     "cross-env": "5.1.0",
     "expect": "1.20.2",
     "karma": "1.7.1",
@@ -15,6 +16,7 @@
     "karma-mocha": "1.3.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.5",
+    "mkdirp": "^0.5.1",
     "mocha": "4.0.1",
     "vue-template-compiler": "2.5.2",
     "webpack": "3.8.0"


### PR DESCRIPTION
The build scripts for each library didn't work on Windows, so I replaced the *nix commands with equivalents from npm.

This does not address the top-level package's _build_ script, which is a bit more involved.  This can at least get people unstuck, and I'm looking into create a node script to run in place of the current _build_ script (since there didn't appear to be a simple replacement for `x & y & z & wait; kill $(jobs -p); … echo "" && exit 0`)