### PR TITLE
Fix tests to avoid issue #112

### DIFF
--- a/libraries/hyperhtml/src/component-tests.js
+++ b/libraries/hyperhtml/src/component-tests.js
@@ -121,14 +121,16 @@ describe('attributes and properties', function() {
     expect(data).toEqual('hyperHTML');
   });
 
-  it('will pass array data as a property', function() {
+  it('will pass array data as a property', async function() {
     ComponentWithProperties(root);
+    await Promise.resolve();
     let wc = root.querySelector('#wc');
     expect(wc.arr).toEqual(['h', 'y', 'p', 'e', 'r', 'H', 'T', 'M', 'L']);
   });
 
-  it('will pass object data as a property', function() {
+  it('will pass object data as a property', async function() {
     ComponentWithProperties(root);
+    await Promise.resolve();
     let wc = root.querySelector('#wc');
     expect(wc.obj).toEqual({org: 'viperHTML', repo: 'hyperHTML'});
   });


### PR DESCRIPTION
In order to avoid misleading attributes on template parsing,
hyperHTML 1.12 improved internally its attribute changes logic.

However, this is not reflected within tests that required
an asynchronous check for the right value.

See: https://github.com/webcomponents/custom-elements-everywhere/issues/112