### PR TITLE
Configure Renovate "master issue"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "major": {
     "automerge": false
   },
+  "masterIssue": true,
   "timezone": "America/Los_Angeles",
   "schedule": ["on friday"]
 }


### PR DESCRIPTION
Renovate has a new "Master issue" feature that I suggest for reducing noise in this repository, the aim being:
- better visibility of updates both pending, open and ignored
- ability to add an "approval" step for selected or all dependencies

With `masterIssue=true`, the only change will be the creation of a long-living issue that tracks all outdated dependencies including ones waiting for schedule, rate limited, open, or closed/ignored. So same level of "noise", but increased visibility. 

Additional config - if desired - can allow you to select all or certain dependencies to gate for approval before PRs. 

The Yarn project has chosen this approach as they have a lot of major updates they need to ignore for a while. You can see their master issue [here](https://renovatebot.com/gh/yarnpkg/yarn/issues/6491).

I am also dogfooding this feature in Renovate [here](https://renovatebot.com/gh/renovatebot/renovate/issues/2599).

Warning: out of sight can also mean out of mind. I'm not sure that gating all updates to require approval is good for all projects because it has the chance of contributing to projects getting deeper out of date. But the way the feature is designed, you can selectively gate only devDependencies, or only major upgrades, etc.

@robdodson please let me know what you think and if you want to set any particular types of updates to be gated for approval already.