### PR TITLE
Preact: Add note about properties that start with on

### DIFF
--- a/libraries/preact/meta/summary.md
+++ b/libraries/preact/meta/summary.md
@@ -6,6 +6,10 @@ on the element instance, Preact will use properties, otherwise it will fallback
 to attributes. The exception to this rule is when it tries to pass rich data,
 like objects or arrays. In those instances it will always use a property.
 
+Because of how JSX defines event listeners, Preact is unable to set properties
+or attributes that start with `on`. They will be interpreted as event listeners
+instead.
+
 <h4 id="preact-handling-events">Handling events</h4>
 
 Preact can listen to native DOM events dispatched from Custom Elements. However,


### PR DESCRIPTION
In Preact (and any other framework using JSX), it's impossible to set a property that starts with "on". 

https://twitter.com/justinfagnani/status/1103155864322498561