### PR TITLE
- Added test for 'value' property correct typing

### DIFF
--- a/libraries/__shared__/webcomponents/src/ce-with-properties.js
+++ b/libraries/__shared__/webcomponents/src/ce-with-properties.js
@@ -46,6 +46,12 @@ class CEWithProperties extends HTMLElement {
   get obj() {
     return this._obj;
   }
+  set value(value) {
+    this._value = value;
+  }
+  get value() {
+    return this._value;
+  }
 }
 
 customElements.define('ce-with-properties', CEWithProperties);

--- a/libraries/angular/src/advanced-tests.js
+++ b/libraries/angular/src/advanced-tests.js
@@ -68,6 +68,16 @@ describe("advanced support", function() {
       let data = wc.obj;
       expect(data).to.eql({ org: "angular", repo: "angular" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      let fixture = TestBed.createComponent(ComponentWithProperties);
+      fixture.detectChanges();
+      let root = fixture.debugElement.nativeElement;
+      let wc = root.querySelector("#wc");
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/angular/src/components.ts
+++ b/libraries/angular/src/components.ts
@@ -88,6 +88,7 @@ export class ComponentWithDifferentViews {
         [str]="data.str"
         [arr]="data.arr"
         [obj]="data.obj"
+        [value]="data.value"
       ></ce-with-properties>
     </div>
   `
@@ -98,7 +99,8 @@ export class ComponentWithProperties {
     num: 42,
     str: 'Angular',
     arr: ['A', 'n', 'g', 'u', 'l', 'a', 'r'],
-    obj: { org: 'angular', repo: 'angular' }
+    obj: { org: 'angular', repo: 'angular' },
+    value: new Date(1985, 9, 26, 9, 0)
   }
 }
 
@@ -134,7 +136,7 @@ export class ComponentWithUnregistered {
   `
 })
 export class ComponentWithImperativeEvent implements OnInit {
-  @ViewChild('customEl') customEl:ElementRef;
+  @ViewChild('customEl', { static: true }) customEl:ElementRef;
   eventHandled = false;
   ngOnInit() {
     this.handleTestEvent = this.handleTestEvent.bind(this);

--- a/libraries/angularjs/src/advanced-tests.js
+++ b/libraries/angularjs/src/advanced-tests.js
@@ -38,6 +38,15 @@ describe("advanced support", () => {
       let data = wc.obj;
       expect(data).to.eql({ org: "angular", repo: "angular" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      let root = prep("<comp-with-props>")
+      scope.$digest()
+      let wc = root.querySelector('#wc')
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", () => {

--- a/libraries/angularjs/src/components.js
+++ b/libraries/angularjs/src/components.js
@@ -62,6 +62,7 @@ const ComponentWithProps = {
         ng-prop-str="$ctrl.str"
         ng-prop-arr="$ctrl.arr"
         ng-prop-obj="$ctrl.obj"
+        ng-prop-value="$ctrl.value"
       ></ce-with-properties>
     </div>
   `,
@@ -73,7 +74,8 @@ const ComponentWithProps = {
         num: 42,
         str: 'Angular',
         arr: ['A', 'n', 'g', 'u', 'l', 'a', 'r'],
-        obj: { org: 'angular', repo: 'angular' }
+        obj: { org: 'angular', repo: 'angular' },
+        value: new Date(1985, 9, 26, 9, 0)
       });
     }
   }

--- a/libraries/dio/src/advanced-tests.js
+++ b/libraries/dio/src/advanced-tests.js
@@ -63,6 +63,14 @@ describe("advanced support", function() {
       let data = wc.obj;
       expect(data).to.eql({ org: "thysultan", repo: "dio.js" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      render(<ComponentWithProperties />, scratch);
+      let wc = scratch.querySelector("#wc");
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/dio/src/components.js
+++ b/libraries/dio/src/components.js
@@ -91,7 +91,8 @@ export class ComponentWithProperties extends Component {
       num: 42,
       str: 'DIO',
       arr: ['D', 'I', 'O'],
-      obj: { org: 'thysultan', repo: 'dio.js' }
+      obj: { org: 'thysultan', repo: 'dio.js' },
+      value: new Date(1985, 9, 26, 9, 0)
     };
     return (
       <div>
@@ -101,6 +102,7 @@ export class ComponentWithProperties extends Component {
           str={data.str}
           arr={data.arr}
           obj={data.obj}
+          value={data.value}
         ></ce-with-properties>
       </div>
     );

--- a/libraries/dojo/src/advanced-tests.ts
+++ b/libraries/dojo/src/advanced-tests.ts
@@ -61,6 +61,15 @@ describe("advanced support", function() {
       const data = wc.obj;
       expect(data).to.eql({ org: "dojo", repo: "dojo" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      const r = renderer(() => w(ComponentWithProperties, {}));
+      r.mount({ domNode: scratch, sync: true });
+      const wc: any = document.querySelector("ce-with-properties");
+      const data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/dojo/src/components.ts
+++ b/libraries/dojo/src/components.ts
@@ -73,7 +73,8 @@ export class ComponentWithProperties extends WidgetBase {
 			num: 42,
 			str: 'Dojo',
 			arr: ['d', 'o', 'j', 'o'],
-			obj: { org: 'dojo', repo: 'dojo' }
+			obj: { org: 'dojo', repo: 'dojo' },
+			value: new Date(1985, 9, 26, 9, 0) as any
 		};
 		return v('ce-with-properties', data);
 	}

--- a/libraries/hybrids/src/advanced-tests.js
+++ b/libraries/hybrids/src/advanced-tests.js
@@ -67,6 +67,16 @@ describe("advanced support", function() {
         done();
       });
     });
+
+    it("will pass Date in the 'value' property", function(done) {
+      this.weight = 2;
+      requestAnimationFrame(() => {
+        const wc = root.firstElementChild.shadowRoot.querySelector('#wc');
+        const data = wc.value || wc.getAttribute("value");
+        expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+        done();
+      });
+    });
   });
 
   describe("events", function() {

--- a/libraries/hybrids/src/components.js
+++ b/libraries/hybrids/src/components.js
@@ -57,6 +57,7 @@ export const ComponentWithProperties = {
       str=${"hybrids"}
       arr=${["h", "y", "b", "r", "i", "d", "s"]}
       obj=${{ library: "hybrids" }}
+      value=${new Date(1985, 9, 26, 9, 0)}
     ></ce-with-properties>
   `,
 };

--- a/libraries/hyperhtml/src/advanced-tests.js
+++ b/libraries/hyperhtml/src/advanced-tests.js
@@ -62,6 +62,13 @@ describe("advanced support", function() {
       let wc = root.querySelector("#wc");
       expect(wc.obj).to.eql({ org: "viperHTML", repo: "hyperHTML" });
     });
+
+    it("will pass Date in the 'value' property", async function() {
+      this.weight = 2;
+      ComponentWithProperties(root);
+      let wc = root.querySelector("#wc");
+      expect(wc.value).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/hyperhtml/src/components.js
+++ b/libraries/hyperhtml/src/components.js
@@ -75,6 +75,7 @@ export const ComponentWithProperties = (root) => hyper(root)`
       str=${'hyperHTML'}
       arr=${['h', 'y', 'p', 'e', 'r', 'H', 'T', 'M', 'L']}
       obj=${{org: 'viperHTML', repo: 'hyperHTML'}}
+      value=${new Date(1985, 9, 26, 9, 0)}
     ></ce-with-properties>
   </div>`;
 

--- a/libraries/litelement/src/advanced-tests.js
+++ b/libraries/litelement/src/advanced-tests.js
@@ -70,6 +70,12 @@ describe("advanced support", function() {
       let data = wc.obj;
       expect(data).to.eql({ org: "polymer", repo: "lit-element" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/litelement/src/components/component-with-properties.js
+++ b/libraries/litelement/src/components/component-with-properties.js
@@ -19,6 +19,7 @@ class ComponentWithProperties extends LitElement {
     this.str = "Lit element";
     this.arr = ["L", "i", "t", "-", "e", "l", "e", "m", "e", "n", "t"];
     this.obj = { org: "polymer", repo: "lit-element" };
+    this.value = new Date(1985, 9, 26, 9, 0);
   }
 
   render() {
@@ -31,6 +32,7 @@ class ComponentWithProperties extends LitElement {
           str="${this.str}"
           .arr="${this.arr}"
           .obj="${this.obj}"
+          .value="${this.value}"
         ></ce-with-properties>
       </div>
     `;

--- a/libraries/mithril/src/advanced-tests.js
+++ b/libraries/mithril/src/advanced-tests.js
@@ -61,6 +61,13 @@ describe("advanced support", function() {
       let wc = root.querySelector("#wc");
       expect(wc.obj).to.eql({ org: "MithrilJS", repo: "mithril.js" });
     });
+
+    it("will pass Date in the 'value' property", async function() {
+      this.weight = 2;
+      m.mount(root, ComponentWithProperties());
+      let wc = root.querySelector("#wc");
+      expect(wc.value).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/mithril/src/components.js
+++ b/libraries/mithril/src/components.js
@@ -80,7 +80,8 @@ export const ComponentWithProperties = () => ({
         num: 42,
         str: 'Mithril',
         arr: ['M', 'i', 't', 'h', 'r', 'i', 'l'],
-        obj: { org: 'MithrilJS', repo: 'mithril.js' }
+        obj: { org: 'MithrilJS', repo: 'mithril.js' },
+        value: new Date(1985, 9, 26, 9, 0)
       })
     )
 })

--- a/libraries/polymer/src/advanced-tests.js
+++ b/libraries/polymer/src/advanced-tests.js
@@ -57,6 +57,12 @@ describe("advanced support", function() {
       let data = wc.obj;
       expect(data).to.eql({ org: "polymer", repo: "polymer" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/polymer/src/components/component-with-properties.js
+++ b/libraries/polymer/src/components/component-with-properties.js
@@ -30,6 +30,12 @@ class ComponentWithProperties extends PolymerElement {
         value: function() {
           return { org: "polymer", repo: "polymer" };
         }
+      },
+      value: {
+        type: Date,
+        value: function() {
+          return new Date(1985, 9, 26, 9, 0);
+        }
       }
     };
   }
@@ -42,6 +48,7 @@ class ComponentWithProperties extends PolymerElement {
           str="[[str]]"
           arr="[[arr]]"
           obj="[[obj]]"
+          value="[[value]]"
         ></ce-with-properties>
       </div>
     `;

--- a/libraries/preact/src/advanced-tests.js
+++ b/libraries/preact/src/advanced-tests.js
@@ -63,6 +63,14 @@ describe("advanced support", function() {
       let data = wc.obj;
       expect(data).to.eql({ org: "developit", repo: "preact" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      let root = render(<ComponentWithProperties />, scratch);
+      let wc = root.querySelector("#wc");
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/preact/src/components.js
+++ b/libraries/preact/src/components.js
@@ -91,7 +91,8 @@ export class ComponentWithProperties extends Component {
       num: 42,
       str: 'Preact',
       arr: ['P', 'r', 'e', 'a', 'c', 't'],
-      obj: { org: 'developit', repo: 'preact' }
+      obj: { org: 'developit', repo: 'preact' },
+      value: new Date(1985, 9, 26, 9, 0)
     };
     return (
       <div>
@@ -101,6 +102,7 @@ export class ComponentWithProperties extends Component {
           str={data.str}
           arr={data.arr}
           obj={data.obj}
+          value={data.value}
         ></ce-with-properties>
       </div>
     );

--- a/libraries/react/src/advanced-tests.js
+++ b/libraries/react/src/advanced-tests.js
@@ -65,6 +65,14 @@ describe("advanced support", function() {
       let data = wc.obj;
       expect(data).to.eql({ org: "facebook", repo: "react" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      let root = ReactDOM.render(<ComponentWithProperties />, scratch);
+      let wc = root.wc;
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/react/src/components.js
+++ b/libraries/react/src/components.js
@@ -92,7 +92,8 @@ export class ComponentWithProperties extends Component {
       num: 42,
       str: 'React',
       arr: ['R', 'e', 'a', 'c', 't'],
-      obj: { org: 'facebook', repo: 'react' }
+      obj: { org: 'facebook', repo: 'react' },
+      value: new Date(1985, 9, 26, 9, 0)
     };
     return (
       <div>
@@ -102,6 +103,7 @@ export class ComponentWithProperties extends Component {
           str={data.str}
           arr={data.arr}
           obj={data.obj}
+          value={data.value}
         ></ce-with-properties>
       </div>
     );

--- a/libraries/skate/src/advanced-tests.js
+++ b/libraries/skate/src/advanced-tests.js
@@ -66,6 +66,16 @@ describe("advanced support", function() {
       let data = wc.obj;
       expect(data).to.eql({ org: "skatejs", repo: "skatejs" });
     });
+
+    it("will pass Date in the 'value' property", async function() {
+      this.weight = 2;
+      let root = document.createElement("component-with-properties");
+      scratch.appendChild(root);
+      await Promise.resolve();
+      let wc = root.shadowRoot.querySelector("#wc");
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/skate/src/components.js
+++ b/libraries/skate/src/components.js
@@ -108,7 +108,8 @@ export class ComponentWithProperties extends withComponent(withPreact()) {
       num: 42,
       str: "Skate",
       arr: ["S", "k", "a", "t", "e"],
-      obj: { org: "skatejs", repo: "skatejs" }
+      obj: { org: "skatejs", repo: "skatejs" },
+      value: new Date(1985, 9, 26, 9, 0)
     };
     return (
       <div>
@@ -119,6 +120,7 @@ export class ComponentWithProperties extends withComponent(withPreact()) {
           str={data.str}
           arr={data.arr}
           obj={data.obj}
+          value={data.value}
         />
       </div>
     );

--- a/libraries/surplus/src/advanced-tests.js
+++ b/libraries/surplus/src/advanced-tests.js
@@ -51,6 +51,16 @@ describe("advanced support", function() {
         expect(data).to.eql({ org: "adam.haile@gmail.com", repo: "surplus" });
       });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      S.root(() => {
+        let root = <ComponentWithProperties />;
+        let wc = root.wc;
+        let data = wc.value;
+        expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+      });
+    });
   });
 
   describe("events", function() {

--- a/libraries/surplus/src/components.js
+++ b/libraries/surplus/src/components.js
@@ -62,7 +62,8 @@ export const ComponentWithProperties = () => {
       num: 42,
       str: 'Surplus',
       arr: ['S', 'u', 'r', 'p', 'l', 'u', 's'],
-      obj: { org: 'adam.haile@gmail.com', repo: 'surplus' }
+      obj: { org: 'adam.haile@gmail.com', repo: 'surplus' },
+      value: new Date(1985, 9, 26, 9, 0)
     };
     return (
       <div>
@@ -72,6 +73,7 @@ export const ComponentWithProperties = () => {
           str={data.str}
           arr={data.arr}
           obj={data.obj}
+          value={data.value}
         ></ce-with-properties>
       </div>
     );

--- a/libraries/svelte/src/advanced-tests.js
+++ b/libraries/svelte/src/advanced-tests.js
@@ -56,6 +56,14 @@ describe("advanced support", function() {
       let data = wc.obj;
       expect(data).to.eql({ org: "sveltejs", repo: "svelte" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      new ComponentWithProperties({ target: scratch });
+      let wc = scratch.querySelector("#wc");
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/svelte/src/components/ComponentWithProperties.html
+++ b/libraries/svelte/src/components/ComponentWithProperties.html
@@ -1,4 +1,4 @@
-<ce-with-properties id="wc" {bool} {num} {str} {arr} {obj}></ce-with-properties>
+<ce-with-properties id="wc" {bool} {num} {str} {arr} {obj} {value}></ce-with-properties>
 
 <script>
     export default {
@@ -8,7 +8,8 @@
                 num: 42,
                 str: 'svelte',
                 arr: ['s', 'v', 'e', 'l', 't', 'e'],
-                obj: { org: 'sveltejs', repo: 'svelte' }
+                obj: { org: 'sveltejs', repo: 'svelte' },
+                value: new Date(1985, 9, 26, 9, 0)
             }
         }
     }

--- a/libraries/vue/src/advanced-tests.js
+++ b/libraries/vue/src/advanced-tests.js
@@ -63,6 +63,14 @@ describe("advanced support", function() {
       let data = wc.obj;
       expect(data).to.eql({ org: "vuejs", repo: "vue" });
     });
+
+    it("will pass Date in the 'value' property", function() {
+      this.weight = 2;
+      let root = new ComponentWithProperties().$mount(scratch).$el;
+      let wc = root.querySelector("#wc");
+      let data = wc.value;
+      expect(data).to.eql(new Date(1985, 9, 26, 9, 0));
+    });
   });
 
   describe("events", function() {

--- a/libraries/vue/src/components.js
+++ b/libraries/vue/src/components.js
@@ -83,6 +83,7 @@ export const ComponentWithProperties = Vue.extend({
         :str.prop="str"
         :arr.prop="arr"
         :obj.prop="obj"
+        :value.prop="value"
       ></ce-with-properties>
     </div>
   `,
@@ -92,7 +93,8 @@ export const ComponentWithProperties = Vue.extend({
       num: 42,
       str: 'Vue',
       arr: ['V', 'u', 'e'],
-      obj: { org: 'vuejs', repo: 'vue' }
+      obj: { org: 'vuejs', repo: 'vue' },
+      value: new Date(1985, 9, 26, 9, 0)
     }
   }
 });


### PR DESCRIPTION
With web-component it will be common to write custom input selector widgets.
To follow the DOM standards, the 'value' property of custom widgets should work like other properties. In particular, the 'value' property should support non-string types as well (for example to implement a date selector widget).

We added then a specific test for the 'value' property, given we found an issue in VueJS about that: https://github.com/vuejs/vue/issues/10255
Only Vue seems to be affected by that.
