### PR TITLE
Fix angular regression

### DIFF
--- a/libraries/angular/meta/expectedResults.json
+++ b/libraries/angular/meta/expectedResults.json
@@ -1,15 +1,15 @@
 {
-  "success": 28,
-  "failed": 2,
+  "success": 30,
+  "failed": 0,
   "skipped": 0,
   "error": false,
   "disconnected": false,
-  "exitCode": 1,
-  "score": 91,
+  "exitCode": 0,
+  "score": 100,
   "basicSupport": {
     "total": 16,
-    "failed": 2,
-    "passed": 14
+    "failed": 0,
+    "passed": 16
   },
   "advancedSupport": {
     "total": 14,

--- a/libraries/angular/src/components.ts
+++ b/libraries/angular/src/components.ts
@@ -20,7 +20,8 @@ import {
   OnInit,
   OnDestroy,
   ViewChild,
-  ElementRef
+  ElementRef,
+  AfterViewInit,
 } from '@angular/core';
 import 'ce-without-children';
 import 'ce-with-children';
@@ -133,10 +134,10 @@ export class ComponentWithUnregistered {
     </div>
   `
 })
-export class ComponentWithImperativeEvent implements OnInit {
-  @ViewChild('customEl') customEl:ElementRef;
+export class ComponentWithImperativeEvent implements AfterViewInit {
+  @ViewChild('customEl') customEl: ElementRef;
   eventHandled = false;
-  ngOnInit() {
+  ngAfterViewInit() {
     this.handleTestEvent = this.handleTestEvent.bind(this);
     this.customEl.nativeElement
       .addEventListener('camelEvent', this.handleTestEvent);


### PR DESCRIPTION
Apparently we want ngAfterInit if we want to access a ViewChild, see https://stackoverflow.com/questions/56958219/viewchild-not-initializing-during-ngoninit