### PR TITLE
Don't deploy a preview for bot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
       - run: npm test
 
       - name: Deploy Preview
-        if: ${{github.event_name == 'pull_request'}}
+        if: ${{github.event_name == 'pull_request' && !(github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]')}}
         uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:
           branch: gh-pages
           folder: out
           target-folder: preview/preview/preview/${{github.event.number}}
       - name: Comment about preview
-        if: ${{github.event_name == 'pull_request'}}
+        if: ${{github.event_name == 'pull_request' && !(github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]')}}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |


### PR DESCRIPTION
Looks like, dependabot will sometimes send out a bunch of changes at the same time (e.g. to update a logging dep in almost every single library), which will cause preview generation to fail with a 403 error.

Since generally no one is looking at the previews for these dep bot changes, better to skip it