### PR TITLE
Time out tests after 15 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Sometimes a dependency upgrade will cause the build to busy-loop

Our builds typically take 5-6 minutes on CI, so this will give them plenty of headroom for normal jobs, but not run a busy loop for six hours.