### PR TITLE
Use createRoot in react-experimental

### DIFF
--- a/libraries/react-experimental/package-lock.json
+++ b/libraries/react-experimental/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "react": "0.0.0-experimental-79ed5e18f-20220217",
-        "react-dom": "0.0.0-experimental-79ed5e18f-20220217"
+        "react": "0.0.0-experimental-d20c3af9d-20220506",
+        "react-dom": "0.0.0-experimental-d20c3af9d-20220506"
       },
       "devDependencies": {
         "@babel/preset-react": "^7.16.0",
@@ -2732,6 +2732,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2959,28 +2960,26 @@
       }
     },
     "node_modules/react": {
-      "version": "0.0.0-experimental-79ed5e18f-20220217",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-79ed5e18f-20220217.tgz",
-      "integrity": "sha512-nrfQLPh5l2wNva+hoeVMosPpgIevR3RVz2Hm8AY0GZ12wFk4OyQv7pu8+nBwzHTEsvZPhEqpskiJGxCtnd0sqg==",
+      "version": "0.0.0-experimental-d20c3af9d-20220506",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-d20c3af9d-20220506.tgz",
+      "integrity": "sha512-ycFoLD9KO267OBmFn7jlPati7QoV4GZc7nXLIITzBwSrLoOYMIWqa8QmM48GUKBwoebq8G2K1EV9tXBlKHSeXw==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "0.0.0-experimental-79ed5e18f-20220217",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-79ed5e18f-20220217.tgz",
-      "integrity": "sha512-38qSW7YNV82kYhjnm4xngMZqSmt3qfYNkuobw0jEE1KiJqHTGAn52N5vvFuYowTCNLhoHXcb6AkLDIsvacdOvA==",
+      "version": "0.0.0-experimental-d20c3af9d-20220506",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-d20c3af9d-20220506.tgz",
+      "integrity": "sha512-Rjtts8RJ3DHNEOMpyNap+igs+yRmB+1mCdXrPiIvwSIQ9fLo5I3yEsrUbwfTuj7t+/EQiFlEf3p+GcFaavrD1g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "0.0.0-experimental-79ed5e18f-20220217"
+        "scheduler": "0.0.0-experimental-d20c3af9d-20220506"
       },
       "peerDependencies": {
-        "react": "0.0.0-experimental-79ed5e18f-20220217"
+        "react": "0.0.0-experimental-d20c3af9d-20220506"
       }
     },
     "node_modules/readdirp": {
@@ -3062,12 +3061,11 @@
       "dev": true
     },
     "node_modules/scheduler": {
-      "version": "0.0.0-experimental-79ed5e18f-20220217",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-79ed5e18f-20220217.tgz",
-      "integrity": "sha512-mjc9Z8k+8HPcPPz1/Oy0bBRKlaxMRkC6hhg3St2PHZAThJws+gRN31Yhv+u8Mlja3hd27fTINQU5OuRIEtykiQ==",
+      "version": "0.0.0-experimental-d20c3af9d-20220506",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-d20c3af9d-20220506.tgz",
+      "integrity": "sha512-/D5HcJzb2Pttd2DUhQV0Wb3oRqMpzcTQBVwgM6SRm0QuZDssOBwOjot32P3Zjd0XYJvYisrW7D82NdWeRXH27w==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -5943,7 +5941,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
@@ -6102,22 +6101,20 @@
       }
     },
     "react": {
-      "version": "0.0.0-experimental-79ed5e18f-20220217",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-79ed5e18f-20220217.tgz",
-      "integrity": "sha512-nrfQLPh5l2wNva+hoeVMosPpgIevR3RVz2Hm8AY0GZ12wFk4OyQv7pu8+nBwzHTEsvZPhEqpskiJGxCtnd0sqg==",
+      "version": "0.0.0-experimental-d20c3af9d-20220506",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-d20c3af9d-20220506.tgz",
+      "integrity": "sha512-ycFoLD9KO267OBmFn7jlPati7QoV4GZc7nXLIITzBwSrLoOYMIWqa8QmM48GUKBwoebq8G2K1EV9tXBlKHSeXw==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-dom": {
-      "version": "0.0.0-experimental-79ed5e18f-20220217",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-79ed5e18f-20220217.tgz",
-      "integrity": "sha512-38qSW7YNV82kYhjnm4xngMZqSmt3qfYNkuobw0jEE1KiJqHTGAn52N5vvFuYowTCNLhoHXcb6AkLDIsvacdOvA==",
+      "version": "0.0.0-experimental-d20c3af9d-20220506",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-d20c3af9d-20220506.tgz",
+      "integrity": "sha512-Rjtts8RJ3DHNEOMpyNap+igs+yRmB+1mCdXrPiIvwSIQ9fLo5I3yEsrUbwfTuj7t+/EQiFlEf3p+GcFaavrD1g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "0.0.0-experimental-79ed5e18f-20220217"
+        "scheduler": "0.0.0-experimental-d20c3af9d-20220506"
       }
     },
     "readdirp": {
@@ -6184,12 +6181,11 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.0.0-experimental-79ed5e18f-20220217",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-79ed5e18f-20220217.tgz",
-      "integrity": "sha512-mjc9Z8k+8HPcPPz1/Oy0bBRKlaxMRkC6hhg3St2PHZAThJws+gRN31Yhv+u8Mlja3hd27fTINQU5OuRIEtykiQ==",
+      "version": "0.0.0-experimental-d20c3af9d-20220506",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-d20c3af9d-20220506.tgz",
+      "integrity": "sha512-/D5HcJzb2Pttd2DUhQV0Wb3oRqMpzcTQBVwgM6SRm0QuZDssOBwOjot32P3Zjd0XYJvYisrW7D82NdWeRXH27w==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {

--- a/libraries/react-experimental/package.json
+++ b/libraries/react-experimental/package.json
@@ -19,7 +19,7 @@
     "webpack": "5.72.0"
   },
   "dependencies": {
-    "react": "0.0.0-experimental-79ed5e18f-20220217",
-    "react-dom": "0.0.0-experimental-79ed5e18f-20220217"
+    "react": "0.0.0-experimental-d20c3af9d-20220506",
+    "react-dom": "0.0.0-experimental-d20c3af9d-20220506"
   }
 }

--- a/libraries/react-experimental/src/advanced-tests.js
+++ b/libraries/react-experimental/src/advanced-tests.js
@@ -47,6 +47,10 @@ before(() => {
   window.IS_REACT_ACT_ENVIRONMENT = true;
 })
 
+after(() => {
+  window.IS_REACT_ACT_ENVIRONMENT = false;
+})
+
 beforeEach(function() {
   scratch = document.createElement("div");
   scratch.id = "scratch";

--- a/libraries/react-experimental/src/advanced-tests.js
+++ b/libraries/react-experimental/src/advanced-tests.js
@@ -16,8 +16,8 @@
  */
 
 import React from "react";
-import ReactDOM from "react-dom";
-import ReactTestUtils from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
 import { expect } from "chai";
 import {
   ComponentWithoutChildren,
@@ -36,15 +36,32 @@ app.id = "app";
 document.body.appendChild(app);
 let scratch; // This will hold the actual element under test.
 
+let reactRoot = null;
+function render(element) {
+  act(() => {
+    reactRoot.render(element);
+  });
+}
+
+before(() => {
+  window.IS_REACT_ACT_ENVIRONMENT = true;
+})
+
 beforeEach(function() {
   scratch = document.createElement("div");
   scratch.id = "scratch";
   app.appendChild(scratch);
+
+  reactRoot = createRoot(scratch);
 });
 
 afterEach(function() {
   app.innerHTML = "";
   scratch = null;
+
+  act(() => {
+    reactRoot.unmount();
+  });
 });
 
 describe("advanced support", function() {
@@ -52,7 +69,14 @@ describe("advanced support", function() {
   describe("attributes and properties", function() {
     it("will pass array data as a property", function() {
       this.weight = 2;
-      let root = ReactDOM.render(<ComponentWithProperties />, scratch);
+      let root;
+      render(
+        <ComponentWithProperties
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let data = wc.arr;
       expect(data).to.eql(["R", "e", "a", "c", "t"]);
@@ -60,7 +84,14 @@ describe("advanced support", function() {
 
     it("will pass object data as a property", function() {
       this.weight = 2;
-      let root = ReactDOM.render(<ComponentWithProperties />, scratch);
+      let root;
+      render(
+        <ComponentWithProperties
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let data = wc.obj;
       expect(data).to.eql({ org: "facebook", repo: "react" });
@@ -70,56 +101,96 @@ describe("advanced support", function() {
   describe("events", function() {
     it("can declaratively listen to a lowercase DOM event dispatched by a Custom Element", function() {
       this.weight = 2;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.lowercase;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
 
     it("can declaratively listen to a kebab-case DOM event dispatched by a Custom Element", function() {
       this.weight = 1;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.kebab;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
 
     it("can declaratively listen to a camelCase DOM event dispatched by a Custom Element", function() {
       this.weight = 1;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.camel;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
 
     it("can declaratively listen to a CAPScase DOM event dispatched by a Custom Element", function() {
       this.weight = 1;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.caps;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
 
     it("can declaratively listen to a PascalCase DOM event dispatched by a Custom Element", function() {
       this.weight = 1;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.pascal;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
   });

--- a/libraries/react-experimental/src/basic-tests.js
+++ b/libraries/react-experimental/src/basic-tests.js
@@ -16,8 +16,9 @@
  */
 
 import React from "react";
-import ReactDOM from "react-dom";
-import ReactTestUtils from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import * as ReactDOM from "react-dom";
 import { expect } from "chai";
 import {
   ComponentWithoutChildren,
@@ -36,15 +37,32 @@ app.id = "app";
 document.body.appendChild(app);
 let scratch; // This will hold the actual element under test.
 
+let reactRoot = null;
+function render(element) {
+  act(() => {
+    reactRoot.render(element);
+  })
+}
+
+before(() => {
+  window.IS_REACT_ACT_ENVIRONMENT = true;
+})
+
 beforeEach(function() {
   scratch = document.createElement("div");
   scratch.id = "scratch";
   app.appendChild(scratch);
+
+  reactRoot = createRoot(scratch);
 });
 
 afterEach(function() {
   app.innerHTML = "";
   scratch = null;
+
+  act(() => {
+    reactRoot.unmount();
+  });
 });
 
 describe("basic support", function() {
@@ -52,7 +70,14 @@ describe("basic support", function() {
   describe("no children", function() {
     it("can display a Custom Element with no children", function() {
       this.weight = 3;
-      let root = ReactDOM.render(<ComponentWithoutChildren />, scratch);
+      let root;
+      render(
+        <ComponentWithoutChildren
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       expect(wc).to.exist;
     });
@@ -72,30 +97,57 @@ describe("basic support", function() {
 
     it("can display a Custom Element with children in a Shadow Root", function() {
       this.weight = 3;
-      let root = ReactDOM.render(<ComponentWithChildren />, scratch);
+      let root;
+      render(
+        <ComponentWithChildren
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       expectHasChildren(wc);
     });
 
     it("can display a Custom Element with children in a Shadow Root and pass in Light DOM children", async function() {
       this.weight = 3;
-      let root = ReactDOM.render(<ComponentWithChildrenRerender />, scratch);
+      let root;
+      render(
+        <ComponentWithChildrenRerender
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
-      await Promise.resolve();
+      await act(async () => {
+        await Promise.resolve();
+      });
       expectHasChildren(wc);
       expect(wc.textContent.includes("2")).to.be.true;
     });
 
     it("can display a Custom Element with children in the Shadow DOM and handle hiding and showing the element", function() {
       this.weight = 3;
-      let root = ReactDOM.render(<ComponentWithDifferentViews />, scratch);
+      let root;
+      render(
+        <ComponentWithDifferentViews
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       expectHasChildren(wc);
-      root.toggle();
+      act(() => {
+        root.toggle();
+      });
       let dummy = ReactDOM.findDOMNode(root.refs.dummy);
       expect(dummy).to.exist;
       expect(dummy.textContent).to.eql("Dummy view");
-      root.toggle();
+      act(() => {
+        root.toggle();
+      });
       wc = root.wc;
       expectHasChildren(wc);
     });
@@ -104,7 +156,14 @@ describe("basic support", function() {
   describe("attributes and properties", function() {
     it("will pass boolean data as either an attribute or a property", function() {
       this.weight = 3;
-      let root = ReactDOM.render(<ComponentWithProperties />, scratch);
+      let root;
+      render(
+        <ComponentWithProperties
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let data = wc.bool || wc.hasAttribute("bool");
       expect(data).to.be.true;
@@ -112,7 +171,14 @@ describe("basic support", function() {
 
     it("will pass numeric data as either an attribute or a property", function() {
       this.weight = 3;
-      let root = ReactDOM.render(<ComponentWithProperties />, scratch);
+      let root;
+      render(
+        <ComponentWithProperties
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let data = wc.num || wc.getAttribute("num");
       expect(parseInt(data, 10)).to.eql(42);
@@ -120,7 +186,14 @@ describe("basic support", function() {
 
     it("will pass string data as either an attribute or a property", function() {
       this.weight = 3;
-      let root = ReactDOM.render(<ComponentWithProperties />, scratch);
+      let root;
+      render(
+        <ComponentWithProperties
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let data = wc.str || wc.getAttribute("str");
       expect(data).to.eql("React");
@@ -166,12 +239,20 @@ describe("basic support", function() {
   describe("events", function() {
     it("can imperatively listen to a DOM event dispatched by a Custom Element", function() {
       this.weight = 3;
-      let root = ReactDOM.render(<ComponentWithImperativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithImperativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.handled;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      })
       expect(handled.textContent).to.eql("true");
     });
   });

--- a/libraries/react-experimental/src/components.js
+++ b/libraries/react-experimental/src/components.js
@@ -16,7 +16,6 @@
  */
 
 import React, { Component } from 'react';
-import { render } from 'react-dom';
 import 'ce-without-children';
 import 'ce-with-children';
 import 'ce-with-properties';

--- a/libraries/react/src/advanced-tests.js
+++ b/libraries/react/src/advanced-tests.js
@@ -16,15 +16,15 @@
  */
 
 import React from "react";
-import ReactDOM from "react-dom";
-import ReactTestUtils from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
 import { expect } from "chai";
 import {
   ComponentWithoutChildren,
   ComponentWithChildren,
   ComponentWithChildrenRerender,
   ComponentWithDifferentViews,
-  ComponentWithProperties,
+ComponentWithProperties,
   ComponentWithUnregistered,
   ComponentWithImperativeEvent,
   ComponentWithDeclarativeEvent
@@ -36,15 +36,32 @@ app.id = "app";
 document.body.appendChild(app);
 let scratch; // This will hold the actual element under test.
 
+let reactRoot = null;
+function render(element) {
+  act(() => {
+    reactRoot.render(element);
+  });
+}
+
+before(() => {
+  window.IS_REACT_ACT_ENVIRONMENT = true;
+})
+
 beforeEach(function() {
   scratch = document.createElement("div");
   scratch.id = "scratch";
   app.appendChild(scratch);
+
+  reactRoot = createRoot(scratch);
 });
 
 afterEach(function() {
   app.innerHTML = "";
   scratch = null;
+
+  act(() => {
+    reactRoot.unmount();
+  });
 });
 
 describe("advanced support", function() {
@@ -52,7 +69,14 @@ describe("advanced support", function() {
   describe("attributes and properties", function() {
     it("will pass array data as a property", function() {
       this.weight = 2;
-      let root = ReactDOM.render(<ComponentWithProperties />, scratch);
+      let root;
+      render(
+        <ComponentWithProperties
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let data = wc.arr;
       expect(data).to.eql(["R", "e", "a", "c", "t"]);
@@ -60,7 +84,14 @@ describe("advanced support", function() {
 
     it("will pass object data as a property", function() {
       this.weight = 2;
-      let root = ReactDOM.render(<ComponentWithProperties />, scratch);
+      let root;
+      render(
+        <ComponentWithProperties
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let data = wc.obj;
       expect(data).to.eql({ org: "facebook", repo: "react" });
@@ -70,56 +101,96 @@ describe("advanced support", function() {
   describe("events", function() {
     it("can declaratively listen to a lowercase DOM event dispatched by a Custom Element", function() {
       this.weight = 2;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.lowercase;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
 
     it("can declaratively listen to a kebab-case DOM event dispatched by a Custom Element", function() {
       this.weight = 1;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.kebab;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
 
     it("can declaratively listen to a camelCase DOM event dispatched by a Custom Element", function() {
       this.weight = 1;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.camel;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
 
     it("can declaratively listen to a CAPScase DOM event dispatched by a Custom Element", function() {
       this.weight = 1;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.caps;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
 
     it("can declaratively listen to a PascalCase DOM event dispatched by a Custom Element", function() {
       this.weight = 1;
-      let root = ReactDOM.render(<ComponentWithDeclarativeEvent />, scratch);
+      let root;
+      render(
+        <ComponentWithDeclarativeEvent
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      );
       let wc = root.wc;
       let handled = root.pascal;
       expect(handled.textContent).to.eql("false");
-      wc.click();
-      root.forceUpdate();
+      act(() => {
+        wc.click();
+      });
       expect(handled.textContent).to.eql("true");
     });
   });

--- a/libraries/react/src/components.js
+++ b/libraries/react/src/components.js
@@ -16,7 +16,6 @@
  */
 
 import React, { Component } from 'react';
-import { render } from 'react-dom';
 import 'ce-without-children';
 import 'ce-with-children';
 import 'ce-with-properties';


### PR DESCRIPTION
Gets rid of the "ReactDOM.render is deprecated" warnings which are displayed in the tests: https://custom-elements-everywhere.com/libraries/react-experimental/results/results.html

Run `npm test` for `react` and `react-experimental` to check test results are still the same.