### PR TITLE
Include library version in test overview

### DIFF
--- a/libraries/__shared__/karma-plugins/karma-custom-html-reporter/index.js
+++ b/libraries/__shared__/karma-plugins/karma-custom-html-reporter/index.js
@@ -120,6 +120,9 @@ var HTMLReporter = function(baseReporterDecorator, config, emitter, logger, help
       overview = suite.ele('header', { class: 'overview' });
 
       // Assemble the Overview
+      let pkg = require(path.join(process.cwd(), './package.json'));
+      let libraryVersion = pkg.dependencies[process.env.LIBRARY_NAME];
+      overview.ele('div', { class: 'title is-6' }, 'Version: ' + libraryVersion);
       overview.ele('div', { class: 'browser title is-6' }, 'Browser: ' + browser.name);
       overview.ele('div', { class: 'timestamp title is-6' }, 'Timestamp: ' + timestamp);
 


### PR DESCRIPTION
Example with https://custom-elements-everywhere.com/libraries/react-experimental/results/results.html: 

```
Version: 0.0.0-experimental-79ed5e18f-20220217
Browser: Chrome Headless 101.0.4951.41 (Linux x86_64)
Timestamp: 5/10/2022, 1:58:27 PM
15 tests / 0 errors / 0 failures / 0 skipped / runtime: 0.025s
```

![localhost_3000_libraries_react-experimental_results_results](https://user-images.githubusercontent.com/12292047/167623784-51e18289-8e34-4b12-9874-d113719c0a43.png)

