### PR TITLE
fix Skate repo link

### DIFF
--- a/libraries/skate/package.json
+++ b/libraries/skate/package.json
@@ -3,7 +3,7 @@
     "test": "wireit",
     "build": "wireit"
   },
-  "library_repo": "solidjs/solid",
+  "library_repo": "skatejs/skatejs",
   "devDependencies": {
     "babel-core": "6.26.3",
     "babel-loader": "9.1.3",


### PR DESCRIPTION
Skate+Preact incorrectly linked to the repo [solidjs/solid](https://github.com/solidjs/solid), this PR updates the link to [skatejs/skatejs](https://github.com/skatejs/skatejs)