### PR TITLE
Add custom element with method

### DIFF
--- a/libraries/__shared__/webcomponents/src/ce-with-methods.js
+++ b/libraries/__shared__/webcomponents/src/ce-with-methods.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class CEWithMethods extends HTMLElement {
+
+    test() {
+        this.innerText = 'Success';
+    }
+
+    connectedCallback() {
+        this.test();
+    }
+
+}
+
+customElements.define('ce-with-methods', CEWithMethods);

--- a/libraries/angular/src/basic-tests.js
+++ b/libraries/angular/src/basic-tests.js
@@ -27,7 +27,8 @@ import {
   ComponentWithProperties,
   ComponentWithUnregistered,
   ComponentWithImperativeEvent,
-  ComponentWithDeclarativeEvent
+  ComponentWithDeclarativeEvent,
+  ComponentWithMethods
 } from "./components";
 
 beforeEach(function() {
@@ -40,7 +41,8 @@ beforeEach(function() {
       ComponentWithProperties,
       ComponentWithUnregistered,
       ComponentWithImperativeEvent,
-      ComponentWithDeclarativeEvent
+      ComponentWithDeclarativeEvent,
+      ComponentWithMethods
     ],
     schemas: [CUSTOM_ELEMENTS_SCHEMA]
   });
@@ -145,6 +147,13 @@ describe("basic support", function() {
       let wc = root.querySelector("#wc");
       let data = wc.str || wc.getAttribute("str");
       expect(data).to.eql("Angular");
+    });
+
+    it('will not overwrite methods', function () {
+      let fixture = TestBed.createComponent(ComponentWithMethods);
+      fixture.detectChanges();
+      let root = fixture.debugElement.nativeElement;
+      expect(root.innerText).to.eql('Success')
     });
   });
 

--- a/libraries/angular/src/components.ts
+++ b/libraries/angular/src/components.ts
@@ -27,6 +27,7 @@ import 'ce-without-children';
 import 'ce-with-children';
 import 'ce-with-properties';
 import 'ce-with-event';
+import 'ce-with-methods';
 
 @Component({
   template: `
@@ -104,6 +105,15 @@ export class ComponentWithProperties {
     camelCaseObj: { label: "passed" }
   }
 }
+
+@Component({
+  template: `
+    <div>
+      <ce-with-methods [test]="true"></ce-with-methods>
+    </div>
+  `
+})
+export class ComponentWithMethods {}
 
 @Component({
   template: `

--- a/libraries/react/src/basic-tests.js
+++ b/libraries/react/src/basic-tests.js
@@ -29,6 +29,7 @@ import {
   ComponentWithUnregistered,
   ComponentWithImperativeEvent,
   ComponentWithDeclarativeEvent,
+  ComponentWithMethods,
 } from "./components";
 
 // Setup the test harness. This will get cleaned out with every test.
@@ -197,6 +198,19 @@ describe("basic support", function () {
       let data = wc.str || wc.getAttribute("str");
       expect(data).to.eql("React");
     });
+
+    it('will not overwrite methods', function () {
+      let root;
+      render(
+        <ComponentWithMethods
+          ref={(current) => {
+            root = current;
+          }}
+        />
+      )
+      let wc = root.wc;
+      expect(wc.innerText).to.eql('Success');
+    })
 
     // TODO: Is it the framework's responsibility to check if the underlying
     // property is defined? Or should it just always assume it is and do its

--- a/libraries/react/src/components.js
+++ b/libraries/react/src/components.js
@@ -20,6 +20,7 @@ import 'ce-without-children';
 import 'ce-with-children';
 import 'ce-with-properties';
 import 'ce-with-event';
+import 'ce-with-methods';
 
 export class ComponentWithoutChildren extends Component {
   render() {
@@ -107,6 +108,14 @@ export class ComponentWithProperties extends Component {
         ></ce-with-properties>
       </div>
     );
+  }
+}
+
+export class ComponentWithMethods extends Component {
+  render() {
+    return <div>
+      <ce-with-methods test ref={(el) => this.wc = el}></ce-with-methods>
+    </div>
   }
 }
 


### PR DESCRIPTION
React 19 has a very naïve heuristic for setting props vs attributes; if it detects a property on the custom element with the same name as the attribute, it sets it as a property. This doesn't work if you have a method on the custom element with the same name as an attribute you are trying to set.

- https://github.com/facebook/react/issues/31689

I've attempted to provide a reproduction here; unfortunately this repository does not behave well on Windows or WSL, which are currently my only two options. I will investigate adding support for Windows devs in another PR.