### PR TITLE
Common tests

### DIFF
--- a/libraries/__shared__/tests/package-lock.json
+++ b/libraries/__shared__/tests/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tests",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "chai": "4.3.10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  }
+}

--- a/libraries/__shared__/tests/package.json
+++ b/libraries/__shared__/tests/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tests",
+  "version": "1.0.0",
+  "description": "",
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "chai": "4.3.10"
+  }
+}

--- a/libraries/__shared__/tests/src/advanced-tests.js
+++ b/libraries/__shared__/tests/src/advanced-tests.js
@@ -37,14 +37,14 @@ export default function (
         this.weight = 2
         const { wc } = await renderComponentWithProperties.call(this)
         let data = wc.arr
-        expect(data).to.eql(['r', 'i', 'o', 't'])
+        expect(data).to.eql(['c', 'u', 's', 't', 'o', 'm'])
       })
 
       it('will pass object data as a property', async function () {
         this.weight = 2
         const { wc } = await renderComponentWithProperties.call(this)
         let data = wc.obj
-        expect(data).to.eql({org: 'riotjs', repo: 'riot'})
+        expect(data).to.eql({org: 'webcomponents', repo: 'custom-elements-everywhere'})
       })
 
       it('will pass object data to a camelCase-named property', async function () {
@@ -59,47 +59,47 @@ export default function (
     describe('events', function () {
       it('can declaratively listen to a lowercase DOM event dispatched by a Custom Element', async function () {
         this.weight = 2
-        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        const { wc, click = wc.click } = await renderComponentWithDeclarativeEvent.call(this)
         expect(wc).to.exist
         let handled = document.querySelector('#lowercase')
         expect(handled.textContent).to.eql('false')
-        wc.click()
+        click()
         expect(handled.textContent).to.eql('true')
       })
 
       it('can declaratively listen to a kebab-case DOM event dispatched by a Custom Element', async function () {
         this.weight = 1
-        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        const { wc, click = wc.click } = await renderComponentWithDeclarativeEvent.call(this)
         let handled = document.querySelector('#kebab')
         expect(handled.textContent).to.eql('false')
-        wc.click()
+        click()
         expect(handled.textContent).to.eql('true')
       })
 
       it('can declaratively listen to a camelCase DOM event dispatched by a Custom Element', async function () {
         this.weight = 1
-        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        const { wc, click = wc.click } = await renderComponentWithDeclarativeEvent.call(this)
         let handled = document.querySelector('#camel')
         expect(handled.textContent).to.eql('false')
-        wc.click()
+        click()
         expect(handled.textContent).to.eql('true')
       })
 
       it('can declaratively listen to a CAPScase DOM event dispatched by a Custom Element', async function () {
         this.weight = 1
-        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        const { wc, click = wc.click } = await renderComponentWithDeclarativeEvent.call(this)
         let handled = document.querySelector('#caps')
         expect(handled.textContent).to.eql('false')
-        wc.click()
+        click()
         expect(handled.textContent).to.eql('true')
       })
 
       it('can declaratively listen to a PascalCase DOM event dispatched by a Custom Element', async function () {
         this.weight = 1
-        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        const { wc, click = wc.click } = await renderComponentWithDeclarativeEvent.call(this)
         let handled = document.querySelector('#pascal')
         expect(handled.textContent).to.eql('false')
-        wc.click()
+        click()
         expect(handled.textContent).to.eql('true')
       })
     })

--- a/libraries/__shared__/tests/src/advanced-tests.js
+++ b/libraries/__shared__/tests/src/advanced-tests.js
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai'
+
+
+function skip() {
+  this.skip();
+  return {};
+}
+export default function (
+  {
+    renderComponentWithProperties = skip,
+    renderComponentWithDeclarativeEvent = skip
+  }
+) {
+
+
+  describe('advanced support', function () {
+
+    describe('attributes and properties', function () {
+      it('will pass array data as a property', async function () {
+        this.weight = 2
+        const { wc } = await renderComponentWithProperties.call(this)
+        let data = wc.arr
+        expect(data).to.eql(['r', 'i', 'o', 't'])
+      })
+
+      it('will pass object data as a property', async function () {
+        this.weight = 2
+        const { wc } = await renderComponentWithProperties.call(this)
+        let data = wc.obj
+        expect(data).to.eql({org: 'riotjs', repo: 'riot'})
+      })
+
+      it('will pass object data to a camelCase-named property', async function () {
+        this.weight = 2
+        const { wc } = await renderComponentWithProperties.call(this)
+        let data = wc.camelCaseObj;
+        expect(data).to.eql({label: "passed"});
+      })
+
+    })
+
+    describe('events', function () {
+      it('can declaratively listen to a lowercase DOM event dispatched by a Custom Element', async function () {
+        this.weight = 2
+        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        expect(wc).to.exist
+        let handled = document.querySelector('#lowercase')
+        expect(handled.textContent).to.eql('false')
+        wc.click()
+        expect(handled.textContent).to.eql('true')
+      })
+
+      it('can declaratively listen to a kebab-case DOM event dispatched by a Custom Element', async function () {
+        this.weight = 1
+        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        let handled = document.querySelector('#kebab')
+        expect(handled.textContent).to.eql('false')
+        wc.click()
+        expect(handled.textContent).to.eql('true')
+      })
+
+      it('can declaratively listen to a camelCase DOM event dispatched by a Custom Element', async function () {
+        this.weight = 1
+        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        let handled = document.querySelector('#camel')
+        expect(handled.textContent).to.eql('false')
+        wc.click()
+        expect(handled.textContent).to.eql('true')
+      })
+
+      it('can declaratively listen to a CAPScase DOM event dispatched by a Custom Element', async function () {
+        this.weight = 1
+        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        let handled = document.querySelector('#caps')
+        expect(handled.textContent).to.eql('false')
+        wc.click()
+        expect(handled.textContent).to.eql('true')
+      })
+
+      it('can declaratively listen to a PascalCase DOM event dispatched by a Custom Element', async function () {
+        this.weight = 1
+        const { wc } = await renderComponentWithDeclarativeEvent.call(this)
+        let handled = document.querySelector('#pascal')
+        expect(handled.textContent).to.eql('false')
+        wc.click()
+        expect(handled.textContent).to.eql('true')
+      })
+    })
+  })
+}

--- a/libraries/__shared__/tests/src/basic-tests.js
+++ b/libraries/__shared__/tests/src/basic-tests.js
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect} from 'chai'
+
+function skip() {
+  this.skip();
+  return {};
+}
+
+export default function (
+  {
+    renderComponentWithoutChildren = skip,
+    renderComponentWithChildren = skip,
+    renderComponentWithChildrenRerender = skip,
+    renderComponentWithDifferentViews = skip,
+    renderComponentWithProperties = skip,
+    renderComponentWithImperativeEvent = skip,
+  }) {
+
+  describe('basic support', function () {
+
+    describe('no children', function () {
+      it('can display a Custom Element with no children', async function () {
+        this.weight = 3
+        const { wc } = await renderComponentWithoutChildren.call(this);
+        expect(wc).to.exist
+      })
+    })
+
+    describe('with children', function () {
+      function expectHasChildren(wc) {
+        expect(wc).to.exist
+        let shadowRoot = wc.shadowRoot
+        let heading = shadowRoot.querySelector('h1')
+        expect(heading).to.exist
+        expect(heading.textContent).to.eql('Test h1')
+        let paragraph = shadowRoot.querySelector('p')
+        expect(paragraph).to.exist
+        expect(paragraph.textContent).to.eql('Test p')
+      }
+
+      it('can display a Custom Element with children in a Shadow Root', async function () {
+        this.weight = 3
+        const { wc } = await renderComponentWithChildren.call(this);
+        expectHasChildren(wc)
+      })
+
+      it('can display a Custom Element with children in a Shadow Root and pass in Light DOM children', async function () {
+        this.weight = 3
+        const { wc } = await renderComponentWithChildrenRerender.call(this);
+        expectHasChildren(wc)
+        expect(wc.textContent.includes('2')).to.be.true
+      })
+
+      it('can display a Custom Element with children in the Shadow DOM and handle hiding and showing the element', async function () {
+        this.weight = 3
+        const { wc, toggle } = await renderComponentWithDifferentViews.call(this);
+        expectHasChildren(wc)
+        toggle()
+        let dummy = document.querySelector('#dummy')
+        expect(dummy).to.exist
+        expect(dummy.textContent).to.eql('Dummy view')
+        toggle()
+        expectHasChildren(wc)
+      })
+    })
+
+    describe('attributes and properties', function () {
+      it('will pass boolean data as either an attribute or a property', async function () {
+        this.weight = 3
+        const { wc } = await renderComponentWithProperties.call(this);
+        let data = wc.bool || wc.hasAttribute('bool')
+        expect(data).to.be.true
+      })
+
+      it('will pass numeric data as either an attribute or a property', async function () {
+        this.weight = 3
+        const { wc } = await renderComponentWithProperties.call(this);
+        let data = wc.num || wc.getAttribute('num')
+        expect(parseInt(data, 10)).to.eql(42)
+      })
+
+      it('will pass string data as either an attribute or a property', async function () {
+        this.weight = 3
+        const { wc } = await renderComponentWithProperties.call(this);
+        let data = wc.str || wc.getAttribute('str')
+        expect(data).to.eql('riot')
+      })
+    })
+
+    describe('events', async function () {
+      it('can imperatively listen to a DOM event dispatched by a Custom Element', async function () {
+        this.weight = 3
+        const { wc } = await renderComponentWithImperativeEvent.call(this)
+        expect(wc).to.exist
+        let handled = document.querySelector('#handled')
+        expect(handled.textContent).to.eql('false')
+        wc.click()
+        expect(handled.textContent).to.eql('true')
+      })
+    })
+  })
+}

--- a/libraries/__shared__/tests/src/basic-tests.js
+++ b/libraries/__shared__/tests/src/basic-tests.js
@@ -72,7 +72,7 @@ export default function (
         const { wc, toggle } = await renderComponentWithDifferentViews.call(this);
         expectHasChildren(wc)
         toggle()
-        let dummy = document.querySelector('#dummy')
+        const dummy = document.querySelector('#dummy')
         expect(dummy).to.exist
         expect(dummy.textContent).to.eql('Dummy view')
         toggle()
@@ -99,18 +99,18 @@ export default function (
         this.weight = 3
         const { wc } = await renderComponentWithProperties.call(this);
         let data = wc.str || wc.getAttribute('str')
-        expect(data).to.eql('riot')
+        expect(data).to.eql('custom')
       })
     })
 
     describe('events', async function () {
       it('can imperatively listen to a DOM event dispatched by a Custom Element', async function () {
         this.weight = 3
-        const { wc } = await renderComponentWithImperativeEvent.call(this)
+        const { wc, click = wc.click } = await renderComponentWithImperativeEvent.call(this)
         expect(wc).to.exist
         let handled = document.querySelector('#handled')
         expect(handled.textContent).to.eql('false')
-        wc.click()
+        click()
         expect(handled.textContent).to.eql('true')
       })
     })

--- a/libraries/react/karma.conf.js
+++ b/libraries/react/karma.conf.js
@@ -61,6 +61,7 @@ module.exports = function(config) {
       resolve: {
         modules: [
           path.resolve(__dirname, '../__shared__/webcomponents/src'),
+          path.resolve(__dirname, '../__shared__/tests/src'),
           path.resolve(__dirname, './node_modules')
         ]
       },

--- a/libraries/react/src/advanced-tests.js
+++ b/libraries/react/src/advanced-tests.js
@@ -30,6 +30,8 @@ import {
   ComponentWithDeclarativeEvent
 } from "./components";
 
+import tests from 'advanced-tests';
+
 // Setup the test harness. This will get cleaned out with every test.
 let app = document.createElement("div");
 app.id = "app";
@@ -37,11 +39,6 @@ document.body.appendChild(app);
 let scratch; // This will hold the actual element under test.
 
 let reactRoot = null;
-function render(element) {
-  act(() => {
-    reactRoot.render(element);
-  });
-}
 
 before(() => {
   window.IS_REACT_ACT_ENVIRONMENT = true;
@@ -68,150 +65,32 @@ afterEach(function() {
   });
 });
 
-describe("advanced support", function() {
 
-  describe("attributes and properties", function() {
-    it("will pass array data as a property", function() {
-      this.weight = 2;
-      let root;
-      render(
-        <ComponentWithProperties
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let data = wc.arr;
-      expect(data).to.eql(["R", "e", "a", "c", "t"]);
-    });
-
-    it("will pass object data as a property", function() {
-      this.weight = 2;
-      let root;
-      render(
-        <ComponentWithProperties
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let data = wc.obj;
-      expect(data).to.eql({ org: "facebook", repo: "react" });
-    });
-
-    it("will pass object data to a camelCase-named property", function() {
-      this.weight = 2;
-      let root;
-      render(
-        <ComponentWithProperties
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let data = wc.camelCaseObj;
-      expect(data).to.eql({ label: "passed" });
-    });
+function render(Component) {
+  let root;
+  act(() => {
+    reactRoot.render(
+      <Component
+        ref={(current) => {
+          root = current;
+        }}
+      />
+    );
   });
+  return {wc: root.wc, root}
+}
 
-  describe("events", function() {
-    it("can declaratively listen to a lowercase DOM event dispatched by a Custom Element", function() {
-      this.weight = 2;
-      let root;
-      render(
-        <ComponentWithDeclarativeEvent
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let handled = root.lowercase;
-      expect(handled.textContent).to.eql("false");
+tests({
+  renderComponentWithProperties() {
+    return render(ComponentWithProperties);
+  },
+  renderComponentWithDeclarativeEvent() {
+    const { wc, root } = render(ComponentWithDeclarativeEvent)
+    function click() {
       act(() => {
         wc.click();
       });
-      expect(handled.textContent).to.eql("true");
-    });
-
-    it("can declaratively listen to a kebab-case DOM event dispatched by a Custom Element", function() {
-      this.weight = 1;
-      let root;
-      render(
-        <ComponentWithDeclarativeEvent
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let handled = root.kebab;
-      expect(handled.textContent).to.eql("false");
-      act(() => {
-        wc.click();
-      });
-      expect(handled.textContent).to.eql("true");
-    });
-
-    it("can declaratively listen to a camelCase DOM event dispatched by a Custom Element", function() {
-      this.weight = 1;
-      let root;
-      render(
-        <ComponentWithDeclarativeEvent
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let handled = root.camel;
-      expect(handled.textContent).to.eql("false");
-      act(() => {
-        wc.click();
-      });
-      expect(handled.textContent).to.eql("true");
-    });
-
-    it("can declaratively listen to a CAPScase DOM event dispatched by a Custom Element", function() {
-      this.weight = 1;
-      let root;
-      render(
-        <ComponentWithDeclarativeEvent
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let handled = root.caps;
-      expect(handled.textContent).to.eql("false");
-      act(() => {
-        wc.click();
-      });
-      expect(handled.textContent).to.eql("true");
-    });
-
-    it("can declaratively listen to a PascalCase DOM event dispatched by a Custom Element", function() {
-      this.weight = 1;
-      let root;
-      render(
-        <ComponentWithDeclarativeEvent
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let handled = root.pascal;
-      expect(handled.textContent).to.eql("false");
-      act(() => {
-        wc.click();
-      });
-      expect(handled.textContent).to.eql("true");
-    });
-  });
-
-});
+    }
+    return { wc, root, click }
+  }
+})

--- a/libraries/react/src/basic-tests.js
+++ b/libraries/react/src/basic-tests.js
@@ -16,10 +16,10 @@
  */
 
 import React from "react";
-import { createRoot } from "react-dom/client";
-import { act } from "react-dom/test-utils";
+import {createRoot} from "react-dom/client";
+import {act} from "react-dom/test-utils";
 import * as ReactDOM from "react-dom";
-import { expect } from "chai";
+import {expect} from "chai";
 import {
   ComponentWithoutChildren,
   ComponentWithChildren,
@@ -31,6 +31,8 @@ import {
   ComponentWithDeclarativeEvent,
 } from "./components";
 
+import tests from 'basic-tests';
+
 // Setup the test harness. This will get cleaned out with every test.
 let app = document.createElement("div");
 app.id = "app";
@@ -38,11 +40,6 @@ document.body.appendChild(app);
 let scratch; // This will hold the actual element under test.
 
 let reactRoot = null;
-function render(element) {
-  act(() => {
-    reactRoot.render(element);
-  });
-}
 
 before(() => {
   window.IS_REACT_ACT_ENVIRONMENT = true;
@@ -65,194 +62,53 @@ afterEach(function () {
   });
 });
 
-describe("basic support", function () {
-  describe("no children", function () {
-    it("can display a Custom Element with no children", function () {
-      this.weight = 3;
-      let root;
-      render(
-        <ComponentWithoutChildren
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      expect(wc).to.exist;
-    });
+function render(Component) {
+  let root;
+  act(() => {
+    reactRoot.render(
+      <Component
+        ref={(current) => {
+          root = current;
+        }}
+      />
+    );
   });
+  return {wc: root.wc, root}
+}
 
-  describe("with children", function () {
-    function expectHasChildren(wc) {
-      expect(wc).to.exist;
-      let shadowRoot = wc.shadowRoot;
-      let heading = shadowRoot.querySelector("h1");
-      expect(heading).to.exist;
-      expect(heading.textContent).to.eql("Test h1");
-      let paragraph = shadowRoot.querySelector("p");
-      expect(paragraph).to.exist;
-      expect(paragraph.textContent).to.eql("Test p");
+tests({
+  renderComponentWithoutChildren() {
+    return render(ComponentWithoutChildren);
+  },
+  renderComponentWithChildren() {
+    return render(ComponentWithChildren);
+  },
+  async renderComponentWithChildrenRerender() {
+    const results = render(ComponentWithChildrenRerender);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    return results;
+  },
+  renderComponentWithProperties() {
+    return render(ComponentWithProperties);
+  },
+  renderComponentWithDifferentViews() {
+    const { wc, root } = render(ComponentWithDifferentViews);
+    function toggle() {
+      act(() => {
+        root.toggle();
+      });
     }
-
-    it("can display a Custom Element with children in a Shadow Root", function () {
-      this.weight = 3;
-      let root;
-      render(
-        <ComponentWithChildren
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      expectHasChildren(wc);
-    });
-
-    it("can display a Custom Element with children in a Shadow Root and pass in Light DOM children", async function () {
-      this.weight = 3;
-      let root;
-      render(
-        <ComponentWithChildrenRerender
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      await act(async () => {
-        await Promise.resolve();
-      });
-      expectHasChildren(wc);
-      expect(wc.textContent.includes("2")).to.be.true;
-    });
-
-    it("can display a Custom Element with children in the Shadow DOM and handle hiding and showing the element", function () {
-      this.weight = 3;
-      let root;
-      render(
-        <ComponentWithDifferentViews
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      expectHasChildren(wc);
-      act(() => {
-        root.toggle();
-      });
-      let dummy = root.dummy.current;
-      expect(dummy).to.exist;
-      expect(dummy.textContent).to.eql("Dummy view");
-      act(() => {
-        root.toggle();
-      });
-      wc = root.wc;
-      expectHasChildren(wc);
-    });
-  });
-
-  describe("attributes and properties", function () {
-    it("will pass boolean data as either an attribute or a property", function () {
-      this.weight = 3;
-      let root;
-      render(
-        <ComponentWithProperties
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let data = wc.bool || wc.hasAttribute("bool");
-      expect(data).to.be.true;
-    });
-
-    it("will pass numeric data as either an attribute or a property", function () {
-      this.weight = 3;
-      let root;
-      render(
-        <ComponentWithProperties
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let data = wc.num || wc.getAttribute("num");
-      expect(parseInt(data, 10)).to.eql(42);
-    });
-
-    it("will pass string data as either an attribute or a property", function () {
-      this.weight = 3;
-      let root;
-      render(
-        <ComponentWithProperties
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let data = wc.str || wc.getAttribute("str");
-      expect(data).to.eql("React");
-    });
-
-    // TODO: Is it the framework's responsibility to check if the underlying
-    // property is defined? Or should it just always assume it is and do its
-    // usual default behavior? Preact will actually check if it's defined and
-    // use an attribute if it is not, otherwise it prefers properties for
-    // everything. Is there a "right" answer in this situation?
-
-    // it('will set boolean attributes on a Custom Element that has not already been defined and upgraded', function() {
-    //   let root = ReactDOM.render(<ComponentWithUnregistered />, scratch);
-    //   let wc = ReactDOM.findDOMNode(root.refs.wc);
-    //   expect(wc.hasAttribute('bool')).to.be.true;
-    // });
-
-    // it('will set numeric attributes on a Custom Element that has not already been defined and upgraded', function() {
-    //   let root = ReactDOM.render(<ComponentWithUnregistered />, scratch);
-    //   let wc = ReactDOM.findDOMNode(root.refs.wc);
-    //   expect(wc.getAttribute('num')).to.eql('42');
-    // });
-
-    // it('will set string attributes on a Custom Element that has not already been defined and upgraded', function() {
-    //   let root = ReactDOM.render(<ComponentWithUnregistered />, scratch);
-    //   let wc = ReactDOM.findDOMNode(root.refs.wc);
-    //   expect(wc.getAttribute('str')).to.eql('React');
-    // });
-
-    // it('will set array attributes on a Custom Element that has not already been defined and upgraded', function() {
-    //   let root = ReactDOM.render(<ComponentWithUnregistered />, scratch);
-    //   let wc = ReactDOM.findDOMNode(root.refs.wc);
-    //   expect(wc.getAttribute('arr')).to.eql(JSON.stringify(['R', 'e', 'a', 'c', 't']));
-    // });
-
-    // it('will set object attributes on a Custom Element that has not already been defined and upgraded', function() {
-    //   let root = ReactDOM.render(<ComponentWithUnregistered />, scratch);
-    //   let wc = ReactDOM.findDOMNode(root.refs.wc);
-    //   expect(wc.getAttribute('obj')).to.eql(JSON.stringify({ org: 'facebook', repo: 'react' }));
-    // });
-  });
-
-  describe("events", function () {
-    it("can imperatively listen to a DOM event dispatched by a Custom Element", function () {
-      this.weight = 3;
-      let root;
-      render(
-        <ComponentWithImperativeEvent
-          ref={(current) => {
-            root = current;
-          }}
-        />
-      );
-      let wc = root.wc;
-      let handled = root.handled;
-      expect(handled.textContent).to.eql("false");
+    return { wc, root, toggle }
+  },
+  renderComponentWithImperativeEvent() {
+    const { wc, root } = render(ComponentWithImperativeEvent)
+    function click() {
       act(() => {
         wc.click();
       });
-      expect(handled.textContent).to.eql("true");
-    });
-  });
+    }
+    return { wc, root, click }
+  }
 });

--- a/libraries/react/src/components.js
+++ b/libraries/react/src/components.js
@@ -78,7 +78,7 @@ export class ComponentWithDifferentViews extends Component {
         {showWC ? (
           <ce-with-children ref={(el) => this.wc = el}></ce-with-children>
         ) : (
-          <div ref={this.dummy}>Dummy view</div>
+          <div id="dummy" ref={this.dummy}>Dummy view</div>
         )}
       </div>
     );
@@ -90,9 +90,9 @@ export class ComponentWithProperties extends Component {
     const data = {
       bool: true,
       num: 42,
-      str: 'React',
-      arr: ['R', 'e', 'a', 'c', 't'],
-      obj: { org: 'facebook', repo: 'react' },
+      str: 'custom',
+      arr: ['c', 'u', 's', 't', 'o', 'm'],
+      obj: { org: 'webcomponents', repo: 'custom-elements-everywhere' },
       camelCaseObj: { label: "passed" }
     };
     return (
@@ -153,7 +153,7 @@ export class ComponentWithImperativeEvent extends Component {
     let state = this.state;
     return (
       <div>
-        <div ref={(el) => this.handled = el}>{state.eventHandled.toString()}</div>
+        <div id="handled" ref={(el) => this.handled = el}>{state.eventHandled.toString()}</div>
         <ce-with-event id="wc" ref={(el) => this.wc = el}></ce-with-event>
       </div>
     );
@@ -195,11 +195,11 @@ export class ComponentWithDeclarativeEvent extends Component {
     let state = this.state;
     return (
       <div>
-        <div ref={(el) => this.lowercase = el}>{state.lowercaseHandled.toString()}</div>
-        <div ref={(el) => this.kebab = el}>{state.kebabHandled.toString()}</div>
-        <div ref={(el) => this.camel = el}>{state.camelHandled.toString()}</div>
-        <div ref={(el) => this.caps = el}>{state.capsHandled.toString()}</div>
-        <div ref={(el) => this.pascal = el}>{state.pascalHandled.toString()}</div>
+        <div id="lowercase" ref={(el) => this.lowercase = el}>{state.lowercaseHandled.toString()}</div>
+        <div id="kebab" ref={(el) => this.kebab = el}>{state.kebabHandled.toString()}</div>
+        <div id="camel" ref={(el) => this.camel = el}>{state.camelHandled.toString()}</div>
+        <div id="caps" ref={(el) => this.caps = el}>{state.capsHandled.toString()}</div>
+        <div id="pascal" ref={(el) => this.pascal = el}>{state.pascalHandled.toString()}</div>
         <ce-with-event id="wc" ref={(el) => this.wc = el}
           onlowercaseevent={this.handleLowercaseEvent}
           onkebab-event={this.handleKebabEvent}

--- a/libraries/riot/karma.conf.js
+++ b/libraries/riot/karma.conf.js
@@ -61,6 +61,7 @@ module.exports = function(config) {
       resolve: {
         modules: [
           path.resolve(__dirname, '../__shared__/webcomponents/src'),
+          path.resolve(__dirname, '../__shared__/tests/src'),
           path.resolve(__dirname, './node_modules')
         ]
       },

--- a/libraries/riot/src/advanced-tests.js
+++ b/libraries/riot/src/advanced-tests.js
@@ -19,8 +19,10 @@ import { expect } from 'chai'
 import { component } from 'riot'
 import {
   ComponentWithProperties,
-  ComponentWithDeclarativeEvent
+  ComponentWithDeclarativeEvent,
 } from './components'
+
+import tests from 'advanced-tests';
 
 // Setup the test harness. This will get cleaned out with every test.
 let app = document.createElement('div')
@@ -39,86 +41,18 @@ afterEach(function() {
   scratch = null
 })
 
-describe('advanced support', function() {
 
-  describe('attributes and properties', function() {
-    it('will pass array data as a property', function() {
-      this.weight = 2
-      component(ComponentWithProperties)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let data = wc.arr
-      expect(data).to.eql(['r', 'i', 'o', 't'])
-    })
+function render(Component) {
+  const el = component(Component)(scratch)
+  return {wc: scratch.querySelector('#wc'), el}
+}
 
-    it('will pass object data as a property', function() {
-      this.weight = 2
-      component(ComponentWithProperties)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let data = wc.obj
-      expect(data).to.eql({ org: 'riotjs', repo: 'riot' })
-    })
 
-    it('will pass object data to a camelCase-named property', function() {
-      this.weight = 2
-      component(ComponentWithProperties)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let data = wc.camelCaseObj;
-      expect(data).to.eql({ label: "passed" });
-    })
-
-  })
-
-  describe('events', function() {
-    it('can declaratively listen to a lowercase DOM event dispatched by a Custom Element', function() {
-      this.weight = 2
-      component(ComponentWithDeclarativeEvent)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expect(wc).to.exist
-      let handled = scratch.querySelector('#lowercase')
-      expect(handled.textContent).to.eql('false')
-      wc.click()
-      expect(handled.textContent).to.eql('true')
-    })
-
-    it('can declaratively listen to a kebab-case DOM event dispatched by a Custom Element', function() {
-      this.weight = 1
-      component(ComponentWithDeclarativeEvent)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let handled = scratch.querySelector('#kebab')
-      expect(handled.textContent).to.eql('false')
-      wc.click()
-      expect(handled.textContent).to.eql('true')
-    })
-
-    it('can declaratively listen to a camelCase DOM event dispatched by a Custom Element', function() {
-      this.weight = 1
-      component(ComponentWithDeclarativeEvent)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let handled = scratch.querySelector('#camel')
-      expect(handled.textContent).to.eql('false')
-      wc.click()
-      expect(handled.textContent).to.eql('true')
-    })
-
-    it('can declaratively listen to a CAPScase DOM event dispatched by a Custom Element', function() {
-      this.weight = 1
-      component(ComponentWithDeclarativeEvent)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let handled = scratch.querySelector('#caps')
-      expect(handled.textContent).to.eql('false')
-      wc.click()
-      expect(handled.textContent).to.eql('true')
-    })
-
-    it('can declaratively listen to a PascalCase DOM event dispatched by a Custom Element', function() {
-      this.weight = 1
-      component(ComponentWithDeclarativeEvent)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let handled = scratch.querySelector('#pascal')
-      expect(handled.textContent).to.eql('false')
-      wc.click()
-      expect(handled.textContent).to.eql('true')
-    })
-  })
-
+tests({
+  renderComponentWithProperties() {
+    return render(ComponentWithProperties)
+  },
+  renderComponentWithDeclarativeEvent() {
+    return render(ComponentWithDeclarativeEvent)
+  }
 })

--- a/libraries/riot/src/basic-tests.js
+++ b/libraries/riot/src/basic-tests.js
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai'
 import { component } from 'riot'
 import {
   ComponentWithoutChildren,
@@ -23,9 +22,10 @@ import {
   ComponentWithChildrenRerender,
   ComponentWithDifferentViews,
   ComponentWithProperties,
-  ComponentWithUnregistered,
   ComponentWithImperativeEvent
 } from './components'
+
+import tests from 'basic-tests';
 
 // Setup the test harness. This will get cleaned out with every test.
 let app = document.createElement('div')
@@ -44,130 +44,29 @@ afterEach(function() {
   scratch = null
 })
 
-describe('basic support', function() {
+function render(Component) {
+  const el = component(Component)(scratch)
+  return {wc: scratch.querySelector('#wc'), el}
+}
 
-  describe('no children', function() {
-    it('can display a Custom Element with no children', function() {
-      this.weight = 3
-      component(ComponentWithoutChildren)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expect(wc).to.exist
-    })
-  })
-
-  describe('with children', function() {
-    function expectHasChildren(wc) {
-      expect(wc).to.exist
-      let shadowRoot = wc.shadowRoot
-      let heading = shadowRoot.querySelector('h1')
-      expect(heading).to.exist
-      expect(heading.textContent).to.eql('Test h1')
-      let paragraph = shadowRoot.querySelector('p')
-      expect(paragraph).to.exist
-      expect(paragraph.textContent).to.eql('Test p')
-    }
-
-    it('can display a Custom Element with children in a Shadow Root', function() {
-      this.weight = 3
-      component(ComponentWithChildren)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expectHasChildren(wc)
-    })
-
-    it('can display a Custom Element with children in a Shadow Root and pass in Light DOM children', function() {
-      this.weight = 3
-      component(ComponentWithChildrenRerender)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expectHasChildren(wc)
-      expect(wc.textContent.includes('2')).to.be.true
-    })
-
-    it('can display a Custom Element with children in the Shadow DOM and handle hiding and showing the element', function() {
-      this.weight = 3
-      const el = component(ComponentWithDifferentViews)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expectHasChildren(wc)
-      el.toggle()
-      let dummy = scratch.querySelector('#dummy')
-      expect(dummy).to.exist
-      expect(dummy.textContent).to.eql('Dummy view')
-      el.toggle()
-      wc = scratch.querySelector('#wc')
-      expectHasChildren(wc)
-    })
-  })
-
-  describe('attributes and properties', function() {
-    it('will pass boolean data as either an attribute or a property', function() {
-      this.weight = 3
-      component(ComponentWithProperties)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let data = wc.bool || wc.hasAttribute('bool')
-      expect(data).to.be.true
-    })
-
-    it('will pass numeric data as either an attribute or a property', function() {
-      this.weight = 3
-      component(ComponentWithProperties)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let data = wc.num || wc.getAttribute('num')
-      expect(parseInt(data, 10)).to.eql(42)
-    })
-
-    it('will pass string data as either an attribute or a property', function() {
-      this.weight = 3
-      component(ComponentWithProperties)(scratch)
-      let wc = scratch.querySelector('#wc')
-      let data = wc.str || wc.getAttribute('str')
-      expect(data).to.eql('riot')
-    })
-
-    // Riot.js passes all the following tests but they must be commented out
-    // being consistent with the other frameworks ¯\_(ツ)_/¯
-    /*
-    it('will set boolean attributes on a Custom Element that has not already been defined and upgraded', function() {
-      component(ComponentWithUnregistered)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expect(wc.hasAttribute('bool')).to.be.true
-    })
-
-    it('will set numeric attributes on a Custom Element that has not already been defined and upgraded', function() {
-      component(ComponentWithUnregistered)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expect(wc.getAttribute('num')).to.eql('42')
-    })
-
-    it('will set string attributes on a Custom Element that has not already been defined and upgraded', function() {
-      component(ComponentWithUnregistered)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expect(wc.getAttribute('str')).to.eql('riot')
-    })
-
-    it('will set array properties on a Custom Element that has not already been defined and upgraded', function() {
-      component(ComponentWithUnregistered)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expect(wc.arr).to.eql(['r', 'i', 'o', 't'])
-    })
-
-    it('will set object properties on a Custom Element that has not already been defined and upgraded', function() {
-      component(ComponentWithUnregistered)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expect(wc.obj).to.eql({ org: 'riotjs', repo: 'riot' })
-    })
-    */
-  })
-
-  describe('events', function() {
-    it('can imperatively listen to a DOM event dispatched by a Custom Element', function() {
-      this.weight = 3
-      component(ComponentWithImperativeEvent)(scratch)
-      let wc = scratch.querySelector('#wc')
-      expect(wc).to.exist
-      let handled = scratch.querySelector('#handled')
-      expect(handled.textContent).to.eql('false')
-      wc.click()
-      expect(handled.textContent).to.eql('true')
-    })
-  })
-
+tests({
+  renderComponentWithoutChildren() {
+    return render(ComponentWithoutChildren)
+  },
+  renderComponentWithChildren() {
+    return render(ComponentWithChildren)
+  },
+  renderComponentWithChildrenRerender() {
+    return render(ComponentWithChildrenRerender)
+  },
+  renderComponentWithDifferentViews() {
+    const {wc, el} = render(ComponentWithDifferentViews)
+    return {wc, el, toggle: () => el.toggle()}
+  },
+  renderComponentWithProperties() {
+    return render(ComponentWithProperties)
+  },
+  renderComponentWithImperativeEvent() {
+    return render(ComponentWithImperativeEvent)
+  }
 })

--- a/libraries/riot/src/components/ComponentWithProperties.riot
+++ b/libraries/riot/src/components/ComponentWithProperties.riot
@@ -5,9 +5,9 @@
       state: {
         bool: true,
         num: 42,
-        str: 'riot',
-        arr: ['r', 'i', 'o', 't'],
-        obj: { org: 'riotjs', repo: 'riot' },
+        str: 'custom',
+        arr: ['c', 'u', 's', 't', 'o', 'm'],
+        obj: { org: 'webcomponents', repo: 'custom-elements-everywhere' },
         camelCaseObj: { label: "passed" },
       }
     }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
         "./libraries/__shared__/karma-plugins/karma-custom-html-reporter:build",
         "./libraries/__shared__/karma-plugins/karma-custom-json-reporter:build",
         "./libraries/__shared__/karma-plugins/karma-mocha:build"
+      ],
+      "files": [
+        "./libraries/__shared__/tests/src/basic-tests.js",
+        "./libraries/__shared__/tests/src/advanced-tests.js"
       ]
     }
   }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -18,6 +18,7 @@ async function install() {
     {name: join('__shared__', 'karma-plugins', 'karma-custom-html-reporter')},
     {name: join('__shared__', 'karma-plugins' , 'karma-custom-json-reporter')},
     {name: join('__shared__', 'karma-plugins', 'karma-mocha')},
+    {name: join('__shared__', 'tests')},
     {name: join('__shared__', 'webcomponents')},
   ];
   const packages = allLibs.map((lib) => join(__dirname, '..', 'libraries', lib.name));


### PR DESCRIPTION
Adding a new test was a bit of a PITA due to the sheer number of libraries involved.

This proposed change (with example implementations in riot and react) moves all test definitions to a common location, with frameworks only having to invoke them with a set of factory functions.

This should hopefully make it easier to:

1. Add a new test across all libraries
2. Add a new library (tests missing factories will gracefully skip)
3. Critically, ensure consistency of behaviour in tests